### PR TITLE
Unit prefix and abbr

### DIFF
--- a/src/units.nim
+++ b/src/units.nim
@@ -1,4 +1,4 @@
-import units/[utils, unitInfo, prefix, ops]
+import units/[utils, unitInfo, ops]
 from sequtils import mapIt
 
 

--- a/src/units.nim
+++ b/src/units.nim
@@ -58,3 +58,35 @@ macro unitQuantity*(code: untyped) =
                 const aname* = 1.0.qname
 
             result.add getAstCompact(genAbbr(qname, aname, ident"x"))    
+
+      
+macro unitPrefix*(code: untyped) =
+    result = newStmtList()
+
+    # implement hasUnitPrefix to satisfy UnitPrefixed
+    for prefix in code:
+        prefix.expectCallOneAsIn "prefix declaration", "prefix: number"
+
+        let (name, value) = (prefix.callName, prefix.callOneArg)
+        name.expectIdentAs "prefix name"
+
+        template genPrefix(name, value, x) =
+            proc name*(x: float): auto = x * value
+
+        result.add getAstCompact(genPrefix(name, value, ident"x"))
+
+
+macro unitAbbr*(code: untyped) =
+    result = newStmtList()
+
+    for abbr in code:
+        abbr.expectAsgnAsIn("prefixed unit abbreviation declaration", "abbr = prefix.unit")
+        let 
+            name = abbr.asgnL.expectIdentAs "prefixed unit abbreviation"
+            what = abbr.asgnR.expectIdentDotPairAsIn("prefixed unit", fmt"{name} = prefixed.unit")
+
+        template genAbbrFun(abbr, prefix, unit, x) =
+            proc abbr*(x: float): auto {.inline.} = x.prefix.unit
+
+        let (prefix, unit) = (what.dotL, what.dotR)
+        result.add getAstCompact(genAbbrFun(name, prefix, unit, ident"x"))

--- a/src/units/ops.nim
+++ b/src/units/ops.nim
@@ -208,5 +208,3 @@ proc printOpsDefinition*(info: SystemInfo): NimNode =
     let delLastResultChar = getAst(delLastChar(ident"result"))
     result[0].body.add delLastResultChar
     result[1].body.add delLastResultChar
-
-        for i in 0..<toUpdate.len: injectManipulatedTypes(info, toUpdate[i], ops[i])

--- a/src/units/utils.nim
+++ b/src/units/utils.nim
@@ -130,3 +130,10 @@ proc expectAsgnAsIn*(node: NimNode, what: string, forms: varargs[string]): NimNo
     if not node.isAsgn:
         node.errorTrace(expectedAsIn, what, formVariants(forms))
     node
+
+
+proc expectIdentDotPairAsIn*(node: NimNode, what: string, forms: varargs[string]): NimNode {.discardable} =
+    ## Check whenever the node is call ident. Return the node for chaining.
+    if not node.isIdentDotPair:
+        node.errorTrace(expectedAsIn, what, formVariants(forms))
+    node

--- a/tests/test_unitAbbr.nim
+++ b/tests/test_unitAbbr.nim
@@ -1,0 +1,15 @@
+from units import unitAbbr
+import test_unitPrefix, test_unitSystem
+
+unitAbbr:
+    ps  = pico.seconds
+    ns  = nano.seconds
+    mis = micro.seconds
+    ms  = mili.seconds
+
+    nm  = nano.meters
+    um  = micro.meters
+    mm  = mili.meters
+    dm  = deci.meters
+    cm  = centi.meters
+    km  = kilo.meters

--- a/tests/test_unitPrefix.nim
+++ b/tests/test_unitPrefix.nim
@@ -1,0 +1,20 @@
+from units import unitPrefix
+from math import `^`
+
+unitPrefix: 
+    atto:    0.1 ^ 18
+    femto:   0.1 ^ 15
+    pico:    0.1 ^ 12
+    nano:    0.1 ^  9
+    micro:   0.1 ^  6
+    mili:    0.1 ^  3
+    centi:   0.1 ^  2
+    deci:    0.1 ^  1
+    deca:   10.0 ^  1
+    hekto:  10.0 ^  2
+    kilo:   10.0 ^  3
+    mega:   10.0 ^  6
+    giga:   10.0 ^  9
+    tera:   10.0 ^ 12
+    peta:   10.0 ^ 15
+    exa:    10.0 ^ 18

--- a/tests/test_unitQuantity.nim
+++ b/tests/test_unitQuantity.nim
@@ -1,25 +1,6 @@
-import units
+from units import unitQuantity
 import test_unitSystem
 
 unitQuantity: 
     Velocity = Length / Time
     Frequency = Time^-1
-
-let 
-    a = 1.0.meters
-    b = 2.0.seconds
-    c = a / b
-
-assert 1 / b is Frequency
-assert b^-1 is Frequency
-assert c is Velocity
-
-let 
-    d = 3.0 * a
-    f = a + d
-
-assert f is Length
-
-echo a
-echo d
-echo f

--- a/tests/test_unitSystem.nim
+++ b/tests/test_unitSystem.nim
@@ -8,9 +8,3 @@ unitSystem si:
     ElectricCurrent: amperes(A)
     Temperature:     kelvins(K)
     Amount:          moles(mol)
-
-let a = Length(10)
-let b = 10.meters
-assert b is Length
-echo a
-echo b

--- a/units.nimble
+++ b/units.nimble
@@ -5,7 +5,7 @@ author        = "lorenzoliuzzo"
 description   = "A Dimensional Analysis Package written in Nim"
 license       = "GPL-3.0-or-later"
 srcDir        = "src"
-skipDir       = @["tests"]
+skipDirs       = @["tests"]
 
 # Dependencies
 requires "nim >= 2.0.2"


### PR DESCRIPTION
Adding unitPrefix and unitAbbr macros to implement prefixed unit:
```nim
unitPrefix: 
    atto:    0.1 ^ 18
    femto:   0.1 ^ 15
    pico:    0.1 ^ 12
    nano:    0.1 ^  9
    micro:   0.1 ^  6
    mili:    0.1 ^  3
    centi:   0.1 ^  2
    deci:    0.1 ^  1
    deca:   10.0 ^  1
    hekto:  10.0 ^  2
    kilo:   10.0 ^  3
    mega:   10.0 ^  6
    giga:   10.0 ^  9
    tera:   10.0 ^ 12
    peta:   10.0 ^ 15
    exa:    10.0 ^ 18
    
    
unitAbbr:
    ps  = pico.seconds
    ms  = milli.seconds

    nm  = nano.meters
    km  = kilo.meters
```